### PR TITLE
Allow AVTs in result-document @format attribute

### DIFF
--- a/2.0/xslt20.rnc
+++ b/2.0/xslt20.rnc
@@ -554,7 +554,7 @@ result-document.element =
    element result-document {
       global.atts,
       extension.atts,
-      attribute format { xsd:QName }?,
+      attribute format { xsd:QName | brace-avt.datatype }?,
       attribute href { xsd:anyURI | brace-avt.datatype }?,
       attribute validation { validation.datatype }?,
       attribute type { xsd:QName }?,


### PR DESCRIPTION
The `<xsl:result-document>` element allows AVTs in the `@format` attribute.
