### PR TITLE
Tighten content model of xsl:analyze-string

### DIFF
--- a/2.0/xslt20.rnc
+++ b/2.0/xslt20.rnc
@@ -173,8 +173,8 @@ analyze-string.element =
       attribute select { expression.datatype },
       attribute regex { avt.datatype },
       attribute flags { avt.datatype }?,
-      matching-substring.element?,
-      non-matching-substring.element?,
+      ((matching-substring.element, non-matching-substring.element?)
+       | non-matching-substring.element),
       fallback.element*
    }
 

--- a/3.0/xslt30.rnc
+++ b/3.0/xslt30.rnc
@@ -1023,7 +1023,8 @@ analyze-string.element =
       | attribute _regex { avt.datatype }),
       (attribute flags { string.datatype | avt.datatype }
       | attribute _flags { avt.datatype })?,
-      (matching-substring.element?, non-matching-substring.element?, fallback.element*)
+      ((matching-substring.element, non-matching-substring.element?) | non-matching-substring.element),
+      fallback.element*
    }
 matching-substring.element =
    element matching-substring {


### PR DESCRIPTION
The specification documents for XSLT 2 and 3 provide an EBNF which says that the content model of xsl:analyze-string is `(xsl:matching-substring?, xsl:non-matching-substring?, xsl:fallback*)`, but the text of the document specifies an additional restriction:

> The content of the xsl:analyze-string instruction must take one of the following forms:
> 1. A single xsl:matching-substring instruction, followed by zero or more xsl:fallback instructions
> 2. A single xsl:non-matching-substring instruction, followed by zero or more xsl:fallback instructions
> 3. A single xsl:matching-substring instruction, followed by a single xsl:non-matching-substring instruction, followed by zero or more xsl:fallback instructions

The existing grammar would allow for an empty `xsl:analyze-string` element, but this is actually not permitted.
